### PR TITLE
Place search is wildcarded on both sides. …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Wazimap Change Log
 ==================
 
+0.2.12 (unreleased)
+-------------------
+
+* FIX: place search is wildcarded on both sides
+
 0.2.11 (20 April 2016)
 -------------------
 

--- a/wazimap/geo.py
+++ b/wazimap/geo.py
@@ -160,7 +160,7 @@ class GeoData(object):
         search_term = search_term.strip()
 
         query = self.geo_model.objects\
-            .filter(Q(name__istartswith=search_term) |
+            .filter(Q(name__icontains=search_term) |
                     Q(geo_code=search_term.upper()))\
 
         if levels:


### PR DESCRIPTION
Fixes https://github.com/Code4SA/wazimap-za/issues/21

This means "cape town" finds "city of cape town"
