### PR TITLE
Make it easier to subclass Geography model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Wazimap Change Log
 -------------------
 
 * FIX: place search is wildcarded on both sides
+* Make it easier to subclass from the default Wazimap Geography model by using GeographyBase
 
 0.2.11 (20 April 2016)
 -------------------

--- a/census/models.py
+++ b/census/models.py
@@ -47,7 +47,7 @@ class SummaryLevel(models.Model):
     
     # Relationships
     parent = models.ForeignKey('self', related_name='children', blank=True, null=True)
-    ancestors = models.ManyToManyField('self', related_name='descendants', symmetrical=False, blank=True, null=True)
+    ancestors = models.ManyToManyField('self', related_name='descendants', symmetrical=False, blank=True)
     
     class Meta:
         ordering = ('summary_level',)

--- a/wazimap/models.py
+++ b/wazimap/models.py
@@ -83,7 +83,7 @@ class GeoMixin(object):
         return self.full_name
 
 
-class Geography(models.Model, GeoMixin):
+class GeographyBase(models.Model, GeoMixin):
     #: The level for this geography (eg. `country`) which, together with
     #: `geo_code`, makes up the unique geo id.
     geo_level = models.CharField(max_length=15, null=False)
@@ -111,6 +111,7 @@ class Geography(models.Model, GeoMixin):
     parent_code = models.CharField(max_length=10, null=True)
 
     class Meta:
+        abstract = True
         unique_together = ('geo_level', 'geo_code')
 
     @property
@@ -136,3 +137,7 @@ class Geography(models.Model, GeoMixin):
             ancestors.append(g)
             g = g.parent
         return ancestors
+
+
+class Geography(GeographyBase):
+    pass


### PR DESCRIPTION
This means other apps can create their own Geography model based on GeographyBase without Django creating a table for the Wazimap Geography. See https://docs.djangoproject.com/es/1.9/topics/db/models/#model-inheritance

This is backwards compatible and doesn't change any migrations.

@jbothma @xybrnet 
