### PR TITLE
force https on external scripts

### DIFF
--- a/wazimap/templates/_base.html
+++ b/wazimap/templates/_base.html
@@ -16,7 +16,7 @@
         <link rel="stylesheet" href="{% static 'css/wazimap.css' %}">
         {% block head_css_extra %}{% endblock %}{% endblock head_css %}
         {% block head_javascript %}
-        <script src="//cdn.jsdelivr.net/g/modernizr@2.7,respond@1.4"></script>
+        <script src="https://cdn.jsdelivr.net/g/modernizr@2.7,respond@1.4"></script>
         {% block head_javascript_extra %}{% endblock %}{% endblock %}
         <!-- Begin Google Analytics -->
         <script>
@@ -158,20 +158,20 @@
 
         {% block body_javascript %}
         <!--[if gte IE 9]><!-->
-        <script src="//cdn.jsdelivr.net/g/jquery@2.1,d3js@3.4,typeahead.js@0.10.2(typeahead.bundle.min.js),underscorejs@1.6,spinjs@1.3,handlebarsjs@1.3(handlebars.min.js)"></script>
+        <script src="https://cdn.jsdelivr.net/g/jquery@2.1,d3js@3.4,typeahead.js@0.10.2(typeahead.bundle.min.js),underscorejs@1.6,spinjs@1.3,handlebarsjs@1.3(handlebars.min.js)"></script>
         <!--<![endif]-->
 
         <!-- local patched version of r2d3 handles percentage widths, HTML overlays -->
         <!--[if lte IE 8]>
         <script src="{{ STATIC_URL }}js/vendor/r2d3.js" charset="utf-8"></script>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/aight/1.2.2/aight.min.js"></script>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/aight/1.2.2/aight.d3.min.js"></script>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.js"></script>
-        <script src="//cdn.jsdelivr.net/g/typeahead.js@0.10.2(typeahead.bundle.min.js),underscorejs@1.6,spinjs@1.3,handlebarsjs@1.3(handlebars.min.js)"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/aight/1.2.2/aight.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/aight/1.2.2/aight.d3.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.js"></script>
+        <script src="https://cdn.jsdelivr.net/g/typeahead.js@0.10.2(typeahead.bundle.min.js),underscorejs@1.6,spinjs@1.3,handlebarsjs@1.3(handlebars.min.js)"></script>
         <![endif]-->
 
         <!--[if lte IE 9]>
-        <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.1/jquery.xdomainrequest.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.1/jquery.xdomainrequest.min.js"></script>
         <![endif]-->
 
         <script src="{% static 'js/app.js' %}"></script>


### PR DESCRIPTION
Force external scripts to call `https` versions. Mostly because `https` versions can still work well on `http` site and not the other way round. Also there is really no reason why not. 
