### PR TITLE
Ensuring all keys are ordered correctly

### DIFF
--- a/wazimap/data/utils.py
+++ b/wazimap/data/utils.py
@@ -404,14 +404,21 @@ def get_stat_data(fields, geo_level, geo_code, session, order_by=None,
             else:
                 key = capitalize(key)
 
-            # enforce key ordering
-            if not data and field in key_order:
+            def add_keys_in_order():
                 for fld in key_order[field]:
                     data[fld] = OrderedDict()
 
+            # enforce key ordering
+            if not data and field in key_order:
+                add_keys_in_order()
+
             # ensure it's there
             if key not in data:
-                data[key] = OrderedDict()
+                # check if key exists in key_order
+                if key in key_order:
+                    add_keys_in_order()
+                else:
+                    data[key] = OrderedDict()
 
             data = data[key]
 

--- a/wazimap/data/utils.py
+++ b/wazimap/data/utils.py
@@ -404,19 +404,20 @@ def get_stat_data(fields, geo_level, geo_code, session, order_by=None,
             else:
                 key = capitalize(key)
 
-            def add_keys_in_order():
+            def add_keys_in_order(data):
                 for fld in key_order[field]:
                     data[fld] = OrderedDict()
+                return data
 
             # enforce key ordering
             if not data and field in key_order:
-                add_keys_in_order()
+                add_keys_in_order(data)
 
             # ensure it's there
             if key not in data:
                 # check if key exists in key_order
-                if key in key_order:
-                    add_keys_in_order()
+                if field in key_order:
+                    add_keys_in_order(data)
                 else:
                     data[key] = OrderedDict()
 


### PR DESCRIPTION
The an example of the problem as described in https://github.com/CodeForAfrica/Wazimap.Kenya/issues/8. 
<img width="1286" alt="screen shot 2016-05-17 at 12 19 16 pm" src="https://cloud.githubusercontent.com/assets/4598145/15317811/bd361c66-1c2b-11e6-9464-f135d91a71fd.png">
The order of the gender data points is not as specified in the code. 'Female' should appear first then 'Male' as specified in the profile below. The color coding for the gender is also off which can cause confusion.
<img width="595" alt="screen shot 2016-05-17 at 12 36 14 pm" src="https://cloud.githubusercontent.com/assets/4598145/15317866/fb8449c0-1c2b-11e6-85db-150997736958.png">

On close examination, the conditions required for the data points to be ordered correctly are not always met when they need to be. (that data does not exist and that the field exists in the key_order dictionary)
<img width="287" alt="screen shot 2016-05-17 at 12 38 47 pm" src="https://cloud.githubusercontent.com/assets/4598145/15317928/584fea2e-1c2c-11e6-9be7-a66839189516.png">

My solution is to check if the field does indeed exist in the key_order even where Data is not none before adding the key in any position.
<img width="365" alt="screen shot 2016-05-17 at 12 53 05 pm" src="https://cloud.githubusercontent.com/assets/4598145/15318348/5aee1862-1c2e-11e6-9335-349bf38ce9cc.png">
