### PR TITLE
Check for parent level in comparative_levels

### DIFF
--- a/wazimap/models.py
+++ b/wazimap/models.py
@@ -3,7 +3,7 @@ import itertools
 
 from django.db import models
 from django.utils.text import slugify
-
+from django.conf import settings
 
 # Geographies
 class GeoMixin(object):
@@ -120,7 +120,7 @@ class GeographyBase(models.Model, GeoMixin):
         the hierarchy.
         """
         if not hasattr(self, '_parent'):
-            if self.parent_level and self.parent_code:
+            if self.parent_level and self.parent_code and self.parent_level in settings.WAZIMAP['comparative_levels']:
                 self._parent = self.__class__.objects.filter(geo_level=self.parent_level, geo_code=self.parent_code).first()
             else:
                 self._parent = None


### PR DESCRIPTION
This ensures that we only check for geographies specified in the `comparative_levels` setting, when retrieving a geography's parents.

This issue comes up when we want to limit the comparative levels, but the geography we're viewing has a parent level outside of those levels specified, e.g. when we want to set province as the root level.

@longhotsummer 
