### PR TITLE
How to page

### DIFF
--- a/census/templates/how_to_use.html
+++ b/census/templates/how_to_use.html
@@ -1,0 +1,6 @@
+{% extends '_base.html' %}{% load partition staticfiles %}
+
+{% block head_title %}Using {{ block.super }}{% endblock %}
+
+{% block content %}
+{% endblock %}

--- a/wazimap/urls.py
+++ b/wazimap/urls.py
@@ -9,7 +9,7 @@ from django.views.generic.base import RedirectView, TemplateView
 from census.views import HealthcheckView, DataView, ExampleView
 
 from wazimap.views import (HomepageView, GeographyDetailView, GeographyJsonView, PlaceSearchJson,
-                           LocateView, DataAPIView, TableAPIView, AboutView, GeographyCompareView,
+                           LocateView, DataAPIView, TableAPIView, AboutView, HowToUseView, GeographyCompareView,
                            GeoAPIView, TableDetailView)
 
 
@@ -33,6 +33,13 @@ urlpatterns = patterns('',
         view    = cache_page(STANDARD_CACHE_TIME)(AboutView.as_view()),
         kwargs  = {},
         name    = 'about',
+    ),
+
+    url(
+        regex   = '^how-to-use$',
+        view    = cache_page(STANDARD_CACHE_TIME)(HowToUseView.as_view()),
+        kwargs  = {},
+        name    = 'how-to-use',
     ),
 
     # e.g. /profiles/province-GT/
@@ -199,7 +206,7 @@ urlpatterns = patterns('',
         kwargs  = {},
         name    = 'healthcheck',
     ),
-    
+
     url(
         regex = '^robots.txt$',
         view = lambda r: HttpResponse(

--- a/wazimap/views.py
+++ b/wazimap/views.py
@@ -267,6 +267,8 @@ class TableAPIView(View):
 class AboutView(TemplateView):
     template_name = 'about.html'
 
+class HowToUseView(TemplateView):
+    template_name = 'how_to_use.html'
 
 class GeographyCompareView(TemplateView):
     template_name = 'profile/head2head.html'


### PR DESCRIPTION
These changes allow implementations of Wazimap to create a "How to use this site" page by overriding the template in place.

@longhotsummer
