### PR TITLE
Correct spelling of method name in call to loadGeometryForGeoIds.

### DIFF
--- a/wazimap/static/js/maps_static.js
+++ b/wazimap/static/js/maps_static.js
@@ -20,7 +20,7 @@ function StaticGeometryLoader(geometry_urls) {
      * callback with an object mapping each geo-id to a GeoJSON object.
      */
     this.loadGeometryForComparison = function(comparison, success) {
-        this.loadGeometryforGeoIds(comparison.dataGeoIDs, success);
+        this.loadGeometryForGeoIds(comparison.dataGeoIDs, success);
     };
 
     /**


### PR DESCRIPTION
Method name is not spelled correctly when it is invoked. This leads to a failure for a map view to load. See, for example, [this](http://www.nepalmap.org/data/map/?table=EDUCATIONLEVELPASSED_SEX&primary_geo_id=country-NP&geo_ids=district|country-NP) in the Nepal implementation of Wazimap or [this](https://kenya.wazimap.org/data/map/?table=HIGHESTEDUCATIONLEVELREACHED&primary_geo_id=country-KE&geo_ids=county|country-KE) in Wazimap Kenya.

Screenshot:
![data-map-wont-load](https://cloud.githubusercontent.com/assets/3824492/19584367/8b4869a8-9709-11e6-8cff-816993739b34.png)
