### PR TITLE
Tables always have a total column

### DIFF
--- a/wazimap/data/tables.py
+++ b/wazimap/data/tables.py
@@ -406,6 +406,7 @@ class FieldTable(SimpleTable):
             self.columns[self.total_column] = {'name': 'Total', 'indent': 0}
         else:
             self.total_column = None
+            self.columns['total'] = {'name': 'Total', 'indent': 0}
 
         session = get_session()
         try:


### PR DESCRIPTION
@longhotsummer 

Possible new patch for #48

As `has_total` has no effect on whether a total column is created or not, should we not always set it as a column?

The exception which was removed in #59 doesn't get raised if run with this change. 
