### PR TITLE
Fix to Embed Charts Error

### DIFF
--- a/wazimap/static/js/embed.chart.frame.js
+++ b/wazimap/static/js/embed.chart.frame.js
@@ -66,7 +66,8 @@ function makeEmbedFrame() {
             chartChartTitle: embedFrame.params.chartTitle,
             chartInitialSort: embedFrame.params.chartInitialSort,
             chartStatType: embedFrame.params.statType,
-            geographyData: embedFrame.data.geographyData
+            geographyData: embedFrame.data.geographyData,
+            comparisonLevels: embedFrame.data.geographyData.comparatives
         });
 
         if (!!embedFrame.parentOrigin) {


### PR DESCRIPTION

<img width="718" alt="screen shot 2016-11-07 at 14 06 29" src="https://cloud.githubusercontent.com/assets/4598145/20055686/690dd812-a4f3-11e6-8bd3-4bc0013a263f.png">

Embedded graphs would not display because of an error with the variable Comparison Levels.

<img width="1673" alt="screen shot 2016-11-07 at 14 04 32" src="https://cloud.githubusercontent.com/assets/4598145/20055678/5dac49a4-a4f3-11e6-84dc-da8226b58d6f.png">

The change below fixes it.