### PR TITLE
Check statType when writing values to map legend

### DIFF
--- a/wazimap/static/js/comparisons.js
+++ b/wazimap/static/js/comparisons.js
@@ -521,8 +521,12 @@ function Comparison(options) {
                     if (comparison.valueType == 'percentage') {
                         return roundNumber(d, precision) + '%';
                     } else {
-                        var prefix = (comparison.statType == 'dollar') ? '$' : '';
-                        return prefix + numberWithCommas(d, precision);
+                        if (comparison.statType == 'percentage') {
+                            return roundNumber(d, precision) + '%';
+                        } else {
+                            var prefix = (comparison.statType == 'dollar') ? '$' : '';
+                            return prefix + numberWithCommas(d, precision);
+                        }
                     }
                 }
             });

--- a/wazimap/static/js/comparisons.js
+++ b/wazimap/static/js/comparisons.js
@@ -518,15 +518,11 @@ function Comparison(options) {
             .data(labelData)
             .text(function(d){
                 if (typeof(d) != 'undefined') {
-                    if (comparison.valueType == 'percentage') {
+                    if (comparison.valueType == 'percentage' || comparison.statType == 'percentage') {
                         return roundNumber(d, precision) + '%';
                     } else {
-                        if (comparison.statType == 'percentage') {
-                            return roundNumber(d, precision) + '%';
-                        } else {
-                            var prefix = (comparison.statType == 'dollar') ? '$' : '';
-                            return prefix + numberWithCommas(d, precision);
-                        }
+                        var prefix = (comparison.statType == 'dollar') ? '$' : '';
+                        return prefix + numberWithCommas(d, precision);
                     }
                 }
             });


### PR DESCRIPTION
When writing the values to the legend, we first check if we're displaying percentages or totals: `comparison.valueType`.

If we're showing totals, we still need to check whether the values are numbers or percentages. This change does that check.

@longhotsummer 