### PR TITLE
Don't remove primary geo when removing geos by level

### DIFF
--- a/wazimap/static/js/comparisons.js
+++ b/wazimap/static/js/comparisons.js
@@ -1524,7 +1524,7 @@ function Comparison(options) {
 
             _.each(comparison.data.geography, function(v, k) {
                 var thisSumlev = k.split('-')[0];
-                if (v.parent_geoid == parentGeoID && thisSumlev == childSumlev) {
+                if (v.parent_geoid == parentGeoID && thisSumlev == childSumlev && k !== comparison.primaryGeoID) {
                     delete comparison.data.data[k];
                 }
             });


### PR DESCRIPTION
@longhotsummer 

This prevents the removal of the primary geo in the comparisons view, when choosing to add all geos in a geo_level, and then selecting to remove them.

If the primary geo is removed, other issues arise due to the incorrect state of how many geos are displaying. Like displaying no geos (the display of which looks 'broken'), and whether or not to display the remove links (no link is displayed if there is only one geo).

It works on the table, map and distribution view.