### PR TITLE
Fixed Broken Map View

### DIFF
--- a/wazimap/static/js/maps_static.js
+++ b/wazimap/static/js/maps_static.js
@@ -42,7 +42,7 @@ function StaticGeometryLoader(geometry_urls) {
         });
 
         // load the levels we need
-        self.loadLevels(_.keys(by_level), function() {
+        self.loadLevels(_.keys(by_level), geo_version, function() {
             var features = {};
 
             _.each(by_level, function(geo_ids, level) {


### PR DESCRIPTION
## Description
The map view is broken because the `geo_version` argument is not passed to the `loadLevels` function in `maps_static.js`.
This PR adds the argument to the function fixing the broken map view.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
