### PR TITLE
writeCitations separately from drawCharts

### DIFF
--- a/wazimap/templates/profile/profile_detail.html
+++ b/wazimap/templates/profile/profile_detail.html
@@ -218,6 +218,7 @@ var makeCharts = function() {
       return c.name;
     });
 
+    $('#citations ul').empty();
     $.each(citations, function(i, c) {
       $('#citations ul')
         .append(


### PR DESCRIPTION
@longhotsummer 

Because we call drawCharts on a window resize, the citations kept being written when comparing places, as the window resizes continually while loading the page.

Not sure if there is a better way to do this?