### PR TITLE
Head2head releases

### DIFF
--- a/wazimap/static/js/widget.geo.select.js
+++ b/wazimap/static/js/widget.geo.select.js
@@ -93,5 +93,5 @@ makeGeoSelectWidget(geoSelect);
 makeGeoSelectWidget($('#compare-place-select'), function(event, datum) {
     var geoId = [profileData.geography.this.geo_level, profileData.geography.this.geo_code].join('-');
     event.stopPropagation();
-    window.location = '/compare/' + geoId + '/vs/' + datum.full_geoid + '/';
+    window.location = '/compare/' + geoId + '/vs/' + datum.full_geoid + '/' + '?release=' + RELEASE;
 });

--- a/wazimap/templates/profile/head2head.html
+++ b/wazimap/templates/profile/head2head.html
@@ -15,8 +15,8 @@
 {% block content_container %}
 
 <div class="head2head-wrapper">
-    <iframe class="frame-left" scrolling="no" src="{% url 'geography_detail' geography_id=geo_id1 %}"></iframe>
-    <iframe class="frame-right" scrolling="no" src="{% url 'geography_detail' geography_id=geo_id2 %}"></iframe>
+    <iframe class="frame-left" scrolling="no" src="{% url 'geography_detail' geography_id=geo_id1 %}?h2h=true&release={{geo1_release_year}}"></iframe>
+    <iframe class="frame-right" scrolling="no" src="{% url 'geography_detail' geography_id=geo_id2 %}?h2h=true&release={{geo2_release_year}}"></iframe>
 
     <div class="clear"></div>
 </div>

--- a/wazimap/templates/profile/profile_detail.html
+++ b/wazimap/templates/profile/profile_detail.html
@@ -228,6 +228,13 @@ var makeCharts = function() {
             .append(_.escape('<' + window.location.href + '>'))
           )
     });
+
+    {% if head2head %}
+    // we remove the source hrefs in the iframes
+    $.each($("a[href='#citations']"), function(i, a) {
+      a.removeAttribute("href");
+    });
+    {% endif %}
 }
 
 var maps = new ProfileMaps();

--- a/wazimap/templates/settings_js.html
+++ b/wazimap/templates/settings_js.html
@@ -24,5 +24,6 @@ var GEOMETRY_URLS = {
 var sumlevMap = {{ geo_data.geo_levels|jsonify|safe }};
 
 var releaseNames = {};
+var RELEASE = '{{ primary_releases.active.year }}';
 {% endblock settings_javascript %}
 </script>

--- a/wazimap/views.py
+++ b/wazimap/views.py
@@ -1,5 +1,6 @@
 from itertools import chain
 import json
+import urllib
 
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
@@ -56,7 +57,7 @@ class GeographyDetailView(BaseGeographyDetailView):
         if self.adjust_slugs and (kwargs.get('slug') or self.geo.slug):
             if kwargs['slug'] != self.geo.slug:
                 kwargs['slug'] = self.geo.slug
-                url = '/profiles/%s-%s-%s' % (self.geo_level, self.geo_code, self.geo.slug)
+                url = '/profiles/%s-%s-%s?%s' % (self.geo_level, self.geo_code, self.geo.slug, urllib.urlencode(request.GET))
                 return redirect(url, permanent=True)
 
         # Skip the parent class's logic completely and go back to basics
@@ -330,12 +331,16 @@ class GeographyCompareView(TemplateView):
             'geo_id2': geo_id2,
         }
 
+        release = self.request.GET.get('release')
         try:
             level, code = geo_id1.split('-', 1)
             page_context['geo1'] = geo_data.get_geography(code, level)
+            page_context['geo1_release_year'] = str(settings.WAZIMAP['primary_release_year'].get(level, release)) if release == settings.WAZIMAP['latest_release_year'] else release
 
             level, code = geo_id2.split('-', 1)
             page_context['geo2'] = geo_data.get_geography(code, level)
+            page_context['geo2_release_year'] = str(settings.WAZIMAP['primary_release_year'].get(level, release)) if release == settings.WAZIMAP['latest_release_year'] else release
+
         except (ValueError, LocationNotFound):
             raise Http404
 


### PR DESCRIPTION
@longhotsummer

These changes allow us to toggle between releases in the head2head view. We set the appropriate release for each of the iframes, using `settings.WAZIMAP['primary_release_year']` to get the correct releases for the geo_levels specified there when we're requesting the latest release.

e.g. wards only have 2011 data, when requesting the 2016 release.

Set add a `h2h` query string parameter know it's a head2head page within the iframe.
