### PR TITLE
Add release to map feature target url

### DIFF
--- a/wazimap/static/js/profile_map.js
+++ b/wazimap/static/js/profile_map.js
@@ -152,7 +152,11 @@ var ProfileMaps = function() {
                     layer.setStyle(self.layerStyle);
                 });
                 layer.on('click', function() {
-                    window.location = '/profiles/' + feature.properties.level + '-' + feature.properties.code + '/';
+                    var location = '/profiles/' + feature.properties.level + '-' + feature.properties.code + '/';
+                    if (feature.properties.release) {
+                        location += '?release=' + feature.properties.release;
+                    }
+                    window.location = location;
                 });
             },
         }).addTo(this.map);


### PR DESCRIPTION
If the release for this page has been set, use it when building the target url for the geos in the map.