### PR TITLE
Remove release from map target url

### DIFF
--- a/wazimap/static/js/profile_map.js
+++ b/wazimap/static/js/profile_map.js
@@ -152,11 +152,7 @@ var ProfileMaps = function() {
                     layer.setStyle(self.layerStyle);
                 });
                 layer.on('click', function() {
-                    var location = '/profiles/' + feature.properties.level + '-' + feature.properties.code + '/';
-                    if (feature.properties.release) {
-                        location += '?release=' + feature.properties.release;
-                    }
-                    window.location = location;
+                    window.location = '/profiles/' + feature.properties.level + '-' + feature.properties.code + '/';
                 });
             },
         }).addTo(this.map);


### PR DESCRIPTION
This change was causing issues when viewing the latest release of a geo_level with all the release years, and navigating to a geo_level which didn't have the the latest release.

This is just a revert so as to fix the error pages until we do this better.