### PR TITLE
Pass latest release around when searching for tables

### DIFF
--- a/wazimap/models/data.py
+++ b/wazimap/models/data.py
@@ -158,7 +158,11 @@ class DataTable(models.Model):
         if year is None and release is None:
             from wazimap.data.utils import current_context
             # use the current context
-            year = current_context().get('year')
+            try:
+                year = current_context().get('year')
+            except ValueError:
+                # We don't have a current context. Use the latest year.
+                year = 'latest'
 
         if year:
             release = self.get_release(year)

--- a/wazimap/models/data.py
+++ b/wazimap/models/data.py
@@ -158,11 +158,7 @@ class DataTable(models.Model):
         if year is None and release is None:
             from wazimap.data.utils import current_context
             # use the current context
-            try:
-                year = current_context().get('year')
-            except ValueError:
-                # We don't have a current context. Use the latest year.
-                year = 'latest'
+            year = current_context().get('year')
 
         if year:
             release = self.get_release(year)

--- a/wazimap/static/js/table.detail.js
+++ b/wazimap/static/js/table.detail.js
@@ -18,6 +18,7 @@ function Table(options) {
         table.$placeSelectContainer = $('#explore-topic-place-picker');
         table.$parentSelect = $('#topic-place-select-parent');
         table.$parentSelectContainer = $('#explore-topic-place-picker-parent');
+        table.releaseYear = options.releaseYear;
         
         // make the side preview expand and collapse
         table.makePreviewExpander();
@@ -287,6 +288,10 @@ function Table(options) {
         }
         if (!!primaryGeoID) {
             url += "&primary_geo_id=" + primaryGeoID
+        }
+
+        if (!! table.releaseYear) {
+            url += "&release=" + table.releaseYear
         }
     
         return url

--- a/wazimap/templates/table/table_detail.html
+++ b/wazimap/templates/table/table_detail.html
@@ -56,7 +56,7 @@
 
             <div class="column-golden-wide expanded-table">
                 <h4>Columns in this table</h4>
-                <ul>{% for column_id, column_data in table.columns.items %}
+                <ul>{% for column_id, column_data in table_columns.items %}
                     <li class="indent-{{ column_data.indent }}">{{ column_data.name }}</li>
                 {% endfor %}</ul>
             </div>

--- a/wazimap/templates/table/table_detail.html
+++ b/wazimap/templates/table/table_detail.html
@@ -1,12 +1,12 @@
 {% extends 'table/_base_table.html' %}
 {% load tabletags static %}
-{% block head_title %}Table {{ table.id }}: {{ table.description }} - {{ block.super }}{% endblock %}
+{% block head_title %}Table {{ table.name }}: {{ table.description }} - {{ block.super }}{% endblock %}
 
 {% block head_facebook_tags %}
-        <meta property="og:title" content="{{ WAZIMAP.name }} table detail: {{ table.id }}" />
+        <meta property="og:title" content="{{ WAZIMAP.name }} table detail: {{ table.name }}" />
         <meta property="og:site_name" content="{{ WAZIMAP.name }}" />
-        <meta property="og:url" content="{{ WAZIMAP.url }}{% url 'table_detail' table.id %}" />
-        <meta property="og:description" content="Description and table metadata for {{ WAZIMAP.name }} table {{ table.id }}: {{ table.description }}." />
+        <meta property="og:url" content="{{ WAZIMAP.url }}{% url 'table_detail' table.name %}" />
+        <meta property="og:description" content="Description and table metadata for {{ WAZIMAP.name }} table {{ table.name }}: {{ table.description }}." />
         <meta property="og:type" content="article" />
         {#}<meta property="og:image" content="" />{#}
 {% endblock %}
@@ -17,7 +17,7 @@
 {% block header_content %}
 <div id="explore" class="wrapper clearfix header-container">
     <section id="explore-topic-place-picker" class="clearfix big-action">
-        <h1 class="article-header">Table {{ table.id }}: {{ table.description }}</h1>
+        <h1 class="article-header">Table {{ table.name }}: {{ table.description }}</h1>
         <h2 class="help-text">Show data from this table: Choose a place or area</h2>
         <div id="topic-place-select-wrapper" class="input-wrapper">
             <input name="topic_place_select" id="topic-place-select" type="text" placeholder="Start typing to pick a place..." autocomplete="off">
@@ -43,7 +43,7 @@
     </header>
     <div class="section-container">
         <section class="clearfix">
-            <h2>Table {{ table.id }}</h2>
+            <h2>Table {{ table.name }}</h2>
             <h2 class="header-for-columns">Table universe: <span class="normal">{{ table.universe }}</span></h2>
             <aside>
                 {% if tabulation.table_versions|length > 1 %}
@@ -69,11 +69,12 @@
 <script src="{% static 'js/table.detail.js' %}"></script>
 <script type="text/javascript">
 var table = new Table({
-    tableID: '{{ table.id }}',
+    tableID: '{{ table.name }}',
     topicSelect: '#topic-select',
     topicSelectContainer: '#query-topic-picker',
     displayHeader: '#header-container',
     displayWrapper: '#table-display',
+    releaseYear: '{{ latest_release_year }}',
 });
 </script>
 {% endblock %}

--- a/wazimap/views.py
+++ b/wazimap/views.py
@@ -368,6 +368,8 @@ class TableDetailView(TemplateView):
     def dispatch(self, *args, **kwargs):
         try:
             self.table = get_datatable(kwargs['table'])
+            # There's no dataset context set here, so we use the latest year
+            self.release = self.table.get_release(year='latest')
         except KeyError:
             raise Http404
 
@@ -376,4 +378,5 @@ class TableDetailView(TemplateView):
     def get_context_data(self, *args, **kwargs):
         return {
             'table': self.table,
+            'latest_release_year': self.release.year,
         }

--- a/wazimap/views.py
+++ b/wazimap/views.py
@@ -376,7 +376,11 @@ class TableDetailView(TemplateView):
         return super(TableDetailView, self).dispatch(*args, **kwargs)
 
     def get_context_data(self, *args, **kwargs):
+        latest_release_year = self.release.year
+        with dataset_context(year=):
+            table_columns = self.table.columns(latest_release_year)
         return {
             'table': self.table,
-            'latest_release_year': self.release.year,
+            'latest_release_year': latest_release_year,
+            'table_columns': cols
         }


### PR DESCRIPTION
@longhotsummer 

When searching for tables from the home page, we don't have a dataset context set, so we use the latest release.

We also pass the latest release to for the table to the template to build the correct data api url.