### PR TITLE
Use name and citation for unique list

### DIFF
--- a/wazimap/templates/profile/profile_detail.html
+++ b/wazimap/templates/profile/profile_detail.html
@@ -215,7 +215,7 @@ var makeCharts = function() {
     });
 
     var citations = _.uniq(citationList, function(c) {
-      return c.name;
+      return c.name + " " + c.citation;
     });
 
     $('#citations ul').empty();

--- a/wazimap/templates/profile/profile_detail.html
+++ b/wazimap/templates/profile/profile_detail.html
@@ -225,7 +225,7 @@ var makeCharts = function() {
           $('<li>')
             .append($('<b>').append(c['name'] + ": "))
             .append(c['citation'])
-            .append(_.escape('<' + window.location.href + '>'))
+            .append(_.escape(' <' + window.location.origin + window.location.pathname + '>'))
           )
     });
 


### PR DESCRIPTION
We filter out some of the citations if we only use name to build the unique list. Using the name and citation retains these items.