### PR TITLE
white noise should be now added as a middleware

### DIFF
--- a/wazimap/wsgi.py
+++ b/wazimap/wsgi.py
@@ -2,6 +2,4 @@ import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wazimap.settings")
 
 from django.core.wsgi import get_wsgi_application
-from whitenoise.django import DjangoWhiteNoise
 application = get_wsgi_application()
-application = DjangoWhiteNoise(application)


### PR DESCRIPTION
Direct wsgi integration for django has been deprecated, recommendation is to add whitenoise as middleware:

http://whitenoise.evans.io/en/stable/changelog.html#v4-0