### PR TITLE
Upgrade Django to 1.11 LTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+env/
 /dist/
 _build/
 *.egg-info/

--- a/census/urls.py
+++ b/census/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url, patterns, include
+from django.conf.urls import url, include
 from django.contrib import admin
 from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponse
@@ -22,7 +22,7 @@ BLOCK_ROBOTS = getattr(settings, 'BLOCK_ROBOTS', False)
 geo_levels = 'ward|municipality|province|country'
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(
         regex   = '^$',
         view    = cache_page(STANDARD_CACHE_TIME)(HomepageView.as_view()),
@@ -223,4 +223,4 @@ urlpatterns = patterns('',
         name    = 'elasticsearch',
     ),
     ## END LOCAL DEV VERSION OF API ##
-)
+]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'VERSION')) as f:
     version = f.read().strip()
 
 install_requires = [
-    'Django>=1.8.0,<1.10',
+    'Django>=1.11.15<1.12.0',
     'SQLAlchemy>=0.9.4',
     'boto>=2.27.0',
     'dj-database-url>=0.4.0',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'VERSION')) as f:
     version = f.read().strip()
 
 install_requires = [
-    'Django>=1.11.15<1.12.0',
+    'Django>=1.11.15,<1.12.0',
     'SQLAlchemy>=0.9.4',
     'boto>=2.27.0',
     'dj-database-url>=0.4.0',

--- a/wazimap/settings.py
+++ b/wazimap/settings.py
@@ -68,17 +68,25 @@ STATICFILES_FINDERS = (
 
 
 # Templates
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.core.context_processors.media',
-    'django.core.context_processors.request',
-    'django.core.context_processors.static',
-    'census.context_processors.api_url',
-    'wazimap.context_processors.wazimap_settings',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+                'census.context_processors.api_url',
+                'wazimap.context_processors.wazimap_settings',
+            ],
+        },
+    },
+]
 
 
 MIDDLEWARE_CLASSES = (

--- a/wazimap/urls.py
+++ b/wazimap/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.contrib import admin
 from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponse
@@ -20,7 +20,7 @@ STANDARD_CACHE_TIME = settings.WAZIMAP['cache_secs']
 EMBED_CACHE_TIME = settings.WAZIMAP.get('embed_cache_secs', STANDARD_CACHE_TIME)
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(
         regex   = '^$',
         view    = cache_page(STANDARD_CACHE_TIME)(HomepageView.as_view()),
@@ -236,4 +236,4 @@ urlpatterns = patterns('',
     #     name    = 'elasticsearch',
     # ),
     # END LOCAL DEV VERSION OF API ##
-)
+]


### PR DESCRIPTION
Older versions of django no longer receive security updates and some of the dependencies like `django-debug-toolbar` no longer support versions `< 1.11`