### PR TITLE
TEMPLATE_DEBUG needs to be define in TEMPLATES settings in Django 1.11

### DIFF
--- a/wazimap/settings.py
+++ b/wazimap/settings.py
@@ -5,7 +5,6 @@ import dj_database_url
 
 
 DEBUG = os.environ.get('DJANGO_DEBUG', 'true') == 'true'
-TEMPLATE_DEBUG = DEBUG
 TESTING = 'test' in sys.argv[1:3]
 
 ROOT_URLCONF = 'wazimap.urls'
@@ -84,6 +83,7 @@ TEMPLATES = [
                 'census.context_processors.api_url',
                 'wazimap.context_processors.wazimap_settings',
             ],
+            'debug': DEBUG,
         },
     },
 ]


### PR DESCRIPTION
`TEMPLATE_DEBUG` was not upgraded to the new `TEMPLATES` settings resulting in the below message:

```
System check identified some issues:

WARNINGS:
?: (1_8.W001) The standalone TEMPLATE_* settings were deprecated in Django 1.8 and the TEMPLATES dictionary takes precedence. You must put the values of the following settings into your default TEMPLATES dict: TEMPLATE_DEBUG.
```
