### PR TITLE
Replace calls to .itervalues with calls to .values()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ install_requires = [
     "paramiko>=1.18.5,<2",
     "psycopg2>=2.7.7",
     "requests>=2.21",
+    "six>=1.12.0",
     "unicodecsv>=0.14.1",
     "whitenoise>=4.1.2",
 ]

--- a/wazimap/geo.py
+++ b/wazimap/geo.py
@@ -283,8 +283,8 @@ class GeoData(object):
         if version is None:
             version = self.global_latest_version
 
-        for features in self.geometry.itervalues():
-            for feature in features.itervalues():
+        for features in self.geometry.values():
+            for feature in features.values():
                 if feature['shape'] and feature['shape'].contains(p):
                     geo = self.get_geography(feature['properties']['code'],
                                              feature['properties']['level'],

--- a/wazimap/management/commands/upgradetables.py
+++ b/wazimap/management/commands/upgradetables.py
@@ -9,10 +9,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         from wazimap.data.tables import FIELD_TABLES, DATA_TABLES
 
-        for table in FIELD_TABLES.itervalues():
+        for table in FIELD_TABLES.values():
             self.upgrade_field_table(table)
 
-        for table in DATA_TABLES.itervalues():
+        for table in DATA_TABLES.values():
             if not hasattr(table, 'fields'):
                 self.upgrade_simple_table(table)
 

--- a/wazimap/migrations/0007_fieldtable_geoversion.py
+++ b/wazimap/migrations/0007_fieldtable_geoversion.py
@@ -19,7 +19,7 @@ def forwards(apps, schema_editor):
     inspector = inspect(session.bind)
 
     try:
-        for data_table in DATA_TABLES.itervalues():
+        for data_table in DATA_TABLES.values():
             db_model = data_table.model
             table = db_model.__table__
 
@@ -51,7 +51,7 @@ def reverse(apps, schema_editor):
     inspector = inspect(session.bind)
 
     try:
-        for data_table in DATA_TABLES.itervalues():
+        for data_table in DATA_TABLES.values():
             db_model = data_table.model
             table = db_model.__table__
 


### PR DESCRIPTION
This change replaces calls to .itervalues() with calls to .values() for dictionaries. This is in line with expectations for python 3. See:

https://docs.python.org/3.7/library/stdtypes.html#dict.values (vs. python 2 at https://docs.python.org/2/library/stdtypes.html#dict.itervalues)

The python future cheatsheet also notes that .values() is idiomatic python 3. Please see https://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items.

It looks to me like the only way to get .itervalues() is to use the six library.

Is using six expected instead? Since 2.X requires Python 3, does anything break by updating these method calls so that users of wazimap can use it without installing six?